### PR TITLE
Io update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ matplotlib
 seaborn
 logomaker
 biopython
-tidytcells>=1.4.0
+tidytcells>=1.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ matplotlib
 seaborn
 logomaker
 biopython
-tidytcells>=1.8.4
+tidytcells>=1.8.5

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -7,9 +7,9 @@ import warnings
 class TestStandardizeDataFrame:
     df_old = pd.DataFrame(
         [
-            ['TRAJ23*01', 'CATQYF', 'TRAV26-1*01', 'TRBJ2-3*01', 'CASQYF', 'TRBV13*01', 'AAA', 'A1', 'B2M', 1],
+            ['TRAJ23*01', 'CATQYF', 'TRAV26-1*01', 'TRBJ2-3*01', 'CASQYF', 'TRBV13*01', 'aaa', 'A1', 'B2M', 1],
             [None, 'CATQYF', None, None, 'CASQYF', None, None, None, None, 1],
-            ['foobar', 'CATQYF', 'TRAV26-1*01', 'TRBJ2-3*01', 'CASQYF', 'TRBV13*01', 'AAA', 'foobar', 'B2M', 1]
+            ['foobar', 'ATQY', 'TRAV26-1*01', 'TRBJ2-3*01', 'CASQYF', 'TRBV13*01', 'AAA', 'foobar', 'B2M', 1]
         ],
         columns=range(10)
     )
@@ -24,7 +24,7 @@ class TestStandardizeDataFrame:
 
 
     def test_standardize_df(self):
-        with pytest.warns(UserWarning, match='Failed to standardise'):
+        with pytest.warns(UserWarning, match='Failed to standardize'):
             result = standardize_dataframe(
                 df_old=self.df_old,
                 col_mapper={


### PR DESCRIPTION
Update standardize_dataframe with new and improved tidytcells
* Better standardization performance
* CDR3s can now be standardized instead of rejected
* Linear peptide epitopes can now be standardized (but epitopes are not rejected on failure because some epitopes may not be peptides)