### PR TITLE
implement seqs2 feature as requested by James

### DIFF
--- a/pyrepseq/util.py
+++ b/pyrepseq/util.py
@@ -18,7 +18,7 @@ def ensure_numpy(arr_like):
 
 
 def check_common_input(
-    seqs, max_edits, max_returns, n_cpu, custom_distance, max_cust_dist, output_type
+    seqs, max_edits, max_returns, n_cpu, custom_distance, max_cust_dist, output_type, seqs2=None
 ):
     assert len(seqs) > 0, "length must be greater than 0"
     try:
@@ -56,17 +56,28 @@ def check_common_input(
         "triplets",
         "ndarray",
     }, "output must be either coo_matrix, triplets, or ndarray"
+    try:
+        for seq in seqs2:
+            assert type(seq) in {
+                str,
+                np.str_,
+            }, "sequences2 must be an iterable of string"
+            assert re.match(
+                r"^[ACDEFGHIKLMNPQRSTVWY]+$", seq
+            ), "sequences2 must contain only valid amino acids"
+    except TypeError:
+        assert seqs2 is None, "sequences2 must be an iterable of string or None"
 
 
-def make_output(triplets, output_type):
+def make_output(triplets, output_type, seqs, seqs2):
     if output_type == "triplets":
         return triplets
 
-    row, col, data, shape = [], [], [], len(seqs)
+    row, col, data = [], [], []
     for triplet in triplets:
         row += [triplet[0], triplet[1]]
         column += [triplet[1], triplet[0]]
         data += [triplet[2], triplet[2]]
-    coo_result = coo_matrix((data, (row, col)), shape=(shape, shape))
+    coo_result = coo_matrix((data, (row, col)), shape=(len(seqs), len(seqs2)))
 
     return coo_result if output_type == "coo_matrix" else coo_result.toarray()

--- a/tests/test_nearest_neighbor.py
+++ b/tests/test_nearest_neighbor.py
@@ -94,6 +94,14 @@ def test_custom_distance(algorithm):
                                max_custom_distance=0), test_output)
 
 
+def test_seq2():
+    test_input1 = ["CAAA", "CADA", "CAAA", "CDKD", "CAAK"]
+    test_input2 = ["CDDD", "CAAK"]
+    test_output = [(1,0,1), (1,2,1), (0,3,1),(1,4,0)]
+    assert set_equal(symspell(test_input1, max_edits=1,
+                               seqs2=test_input2), test_output)
+
+
 @pytest.mark.skip(reason="very slow")
 @pytest.mark.parametrize("algorithm", ALGORITHMS)
 def test_bulk(algorithm):


### PR DESCRIPTION
Add new feature
- allow nearest neighbor comparison to be done across 2 sets of sequences resulting in N2*N combinations
  - compared to before, when 1 set of sequences is given, every sequences are compared against every other sequences resulting in N**2 combinations.

Fix broken feature
- fix symspell algorithm not performing input validation
- incorrect output of sparse matrix

Example below
```py
    test_input1 = ["CAAA", "CADA", "CAAA", "CDKD", "CAAK"]
    test_input2 = ["CDDD", "CAAK"]
    test_output = [(1,0,1), (1,2,1), (0,3,1), (1,4,0)]
    assert set_equal(symspell(test_input1, max_edits=1, seqs2=test_input2), test_output)
```