### PR TITLE
Fix function call discrepancies between TcrMetric and Tcrdist variants

### DIFF
--- a/pyrepseq/metric/tcr_metric/tcr_levenshtein.py
+++ b/pyrepseq/metric/tcr_metric/tcr_levenshtein.py
@@ -142,10 +142,10 @@ class TcrLevenshtein(TcrMetric):
         return columns_to_compare
             
     def _calc_cdist_matrix_for_column(
-        self, anchor_tcrs: DataFrame, comparison_tcrs: DataFrame, column: str
+        self, anchors: DataFrame, comparisons: DataFrame, column: str
     ) -> ndarray:
-        anchors = anchor_tcrs[column]
-        comparisons = comparison_tcrs[column]
+        anchors = anchors[column]
+        comparisons = comparisons[column]
         cdist = process.cdist(anchors, comparisons, scorer=self._levenshtein_scorer)
 
         if "A" in column:

--- a/pyrepseq/metric/tcr_metric/tcrdist/tcrdist_metric.py
+++ b/pyrepseq/metric/tcr_metric/tcrdist/tcrdist_metric.py
@@ -43,24 +43,26 @@ class AbstractTcrdist(TcrMetric):
         pass
 
     def calc_cdist_matrix(
-        self, anchor_tcrs: DataFrame, comparison_tcrs: DataFrame
+        self, anchors: DataFrame, comparisons: DataFrame
     ) -> ndarray:
+        super().calc_cdist_matrix(anchors, comparisons)
+        
         cdist_matrices = []
 
         if TcrChain.ALPHA in self._chains_to_compare:
-            alpha_result = self._calc_alpha_cdist(anchor_tcrs, comparison_tcrs)
+            alpha_result = self._calc_alpha_cdist(anchors, comparisons)
             cdist_matrices.append(alpha_result)
         if TcrChain.BETA in self._chains_to_compare:
-            beta_result = self._calc_beta_cdist(anchor_tcrs, comparison_tcrs)
+            beta_result = self._calc_beta_cdist(anchors, comparisons)
             cdist_matrices.append(beta_result)
 
         return sum(cdist_matrices)
 
     def _calc_alpha_cdist(
-        self, anchor_tcrs: DataFrame, comparison_tcrs: DataFrame
+        self, anchors: DataFrame, comparisons: DataFrame
     ) -> ndarray:
         result = tcrdist_interface.calc_alpha_cdist_matrices(
-            anchor_tcrs, comparison_tcrs
+            anchors, comparisons
         )
         if self._tcrdist_type is TcrdistType.CDR3:
             return result["cdr3_a_aa"]
@@ -68,18 +70,19 @@ class AbstractTcrdist(TcrMetric):
             return result["tcrdist"]
 
     def _calc_beta_cdist(
-        self, anchor_tcrs: DataFrame, comparison_tcrs: DataFrame
+        self, anchors: DataFrame, comparisons: DataFrame
     ) -> ndarray:
         result = tcrdist_interface.calc_beta_cdist_matrices(
-            anchor_tcrs, comparison_tcrs
+            anchors, comparisons
         )
         if self._tcrdist_type is TcrdistType.CDR3:
             return result["cdr3_b_aa"]
         else:
             return result["tcrdist"]
 
-    def calc_pdist_vector(self, tcrs: DataFrame) -> ndarray:
-        pdist_matrix = self.calc_cdist_matrix(tcrs, tcrs)
+    def calc_pdist_vector(self, instances: DataFrame) -> ndarray:
+        super().calc_pdist_vector(instances)
+        pdist_matrix = self.calc_cdist_matrix(instances, instances)
         pdist_vector = distance.squareform(pdist_matrix, checks=False)
         return pdist_vector
 


### PR DESCRIPTION
* Correct discrepancies in function call signatures between metrics that were using old code (parameter names were different, e.g. `anchor_tcrs` instead of `anchors`)