### PR TITLE
Fix bug in pcDelta when setting maxseqs

### DIFF
--- a/pyrepseq/distance.py
+++ b/pyrepseq/distance.py
@@ -125,7 +125,7 @@ def downsample(seqs: Union[Iterable[str], DataFrame], maxseqs: Optional[int] = N
     Random subset of maxseqs elements from the input collection.
     If maxseqs is None, returns the input collection without modification.
     """
-    if maxseqs is None:
+    if maxseqs is None or seqs is None:
         return seqs
 
     if len(seqs) <= maxseqs:

--- a/pyrepseq/distance.py
+++ b/pyrepseq/distance.py
@@ -106,7 +106,7 @@ def cdist(stringsA, stringsB, metric=None, dtype=np.uint8, **kwargs):
     return dm
 
 
-def downsample(seqs: Union[Iterable[str], DataFrame], maxseqs: Optional[int] = None):
+def downsample(seqs: Union[Iterable[str], DataFrame, None], maxseqs: Optional[int] = None):
     """
     Random downsampling of a list of sequences.
     Also works for standard pyrepseq TCR DataFrames (see :py:func:`pyrepseq.io.standardize_dataframe`).

--- a/pyrepseq/util.py
+++ b/pyrepseq/util.py
@@ -6,6 +6,7 @@ import logomaker as lm
 from pandas import DataFrame
 from warnings import warn
 
+
 def align_seqs(seqs):
     """Align multiple sequences using mafft-linsi with default parameters.
 
@@ -33,6 +34,7 @@ def align_seqs(seqs):
     child.stdin.close()
     return [str(seq.seq) for seq in seqs_aligned]
 
+
 def seqs_to_regex(seqs, align=True):
     """Turn a list of sequences into a regular expression.
 
@@ -55,6 +57,7 @@ def seqs_to_regex(seqs, align=True):
             regex += '?'
     return regex
     
+
 def seqs_to_consensus(seqs, align=True):
     """Turn a list of sequences into a consensus sequence.
 
@@ -76,6 +79,7 @@ def seqs_to_consensus(seqs, align=True):
         s += row.idxmax()
     return s
 
+
 def ensure_numpy(arr_like):
     module = type(arr_like).__module__
     if module == "pandas.core.series":
@@ -83,6 +87,7 @@ def ensure_numpy(arr_like):
     if module == "numpy":
         return arr_like
     return np.array(arr_like)
+
 
 def convert_tuple_to_dataframe_if_necessary(seqs):
     if not (isinstance(seqs, tuple) and len(seqs) == 2):

--- a/tests/test_pc_delta.py
+++ b/tests/test_pc_delta.py
@@ -19,6 +19,11 @@ def test_with_one_arg(arg, expected):
     assert np.array_equal(results, expected)
 
 
+def test_with_one_arg_with_downsampling():
+    results = prs.pcDelta(["A", "A", "A"], bins=range(5), maxseqs=2)
+    assert np.array_equal(results, np.array([1,0,0,0]))
+
+
 def test_with_one_df(mock_data_df):
     results = prs.pcDelta(mock_data_df, bins=range(12))
     expected = np.array([1.0/3.0,0,0,0,0,0,0,0,0,0,2.0/3.0])


### PR DESCRIPTION
* Bug where pcDelta breaks when passing in only one argument but setting maxseqs which triggers the downsampling coroutine
   * since seqs2 is None and downsampling tries to downsample it assuming that it is iterable, it throws an error
* This bug is now fixed by an early return in downsampling if the seqs argument is set to None