### PR TITLE
Symdel progress

### DIFF
--- a/pyrepseq/nn.py
+++ b/pyrepseq/nn.py
@@ -1,14 +1,13 @@
 from scipy.spatial import KDTree
 import numpy as np
 import pandas as pd
-import tqdm
+import tqdm.auto
 from rapidfuzz.distance.Levenshtein import distance as levenshtein
 from rapidfuzz.distance.Hamming import distance as hamming
 from scipy.sparse import coo_matrix
 from rapidfuzz.process import extract
 from multiprocessing import Pool
 
-import tqdm.auto
 from .distance import levenshtein_neighbors, hamming_neighbors
 from itertools import combinations, chain
 from .util import ensure_numpy

--- a/pyrepseq/nn.py
+++ b/pyrepseq/nn.py
@@ -1,11 +1,14 @@
 from scipy.spatial import KDTree
 import numpy as np
 import pandas as pd
+import tqdm
 from rapidfuzz.distance.Levenshtein import distance as levenshtein
 from rapidfuzz.distance.Hamming import distance as hamming
 from scipy.sparse import coo_matrix
 from rapidfuzz.process import extract
 from multiprocessing import Pool
+
+import tqdm.auto
 from .distance import levenshtein_neighbors, hamming_neighbors
 from itertools import combinations, chain
 from .util import ensure_numpy
@@ -358,7 +361,7 @@ def _hamming_replacement(seq_a, seq_b):
 
 
 def _symdel_lookup(index, seqs, max_edits, max_returns,
-                    custom_distance, max_custom_dist, seqs2, single_seqs_mode):
+                    custom_distance, max_custom_dist, seqs2, single_seqs_mode, progress):
     ans = []
     threshold = max_custom_dist
     if custom_distance in (None, 'hamming') or max_custom_dist == float('inf'):
@@ -369,7 +372,12 @@ def _symdel_lookup(index, seqs, max_edits, max_returns,
     elif custom_distance is None:
         custom_distance = levenshtein
 
-    for i, seq in enumerate(seqs2):
+    if progress:
+        seqs2_loop = tqdm.auto.tqdm(enumerate(seqs2), total=len(seqs2))
+    else:
+        seqs2_loop = enumerate(seqs2)
+
+    for i, seq in seqs2_loop:
         j_indices, count = set(), 0
         for comb in _comb_gen(seq, max_edits):
             if comb not in index:
@@ -395,9 +403,9 @@ def _symdel_lookup(index, seqs, max_edits, max_returns,
 
 def symdel(seqs, max_edits=1, max_returns=None, n_cpu=1,
              custom_distance=None, max_custom_distance=float('inf'),
-             output_type='triplets', seqs2=None):
+             output_type='triplets', seqs2=None, progress=False):
     """
-    List all neighboring CDR3B sequences efficiently within the given distance.
+    List all neighboring sequences efficiently within the given distance.
     This is an improved version over the hash-based.
 
     If seqs2 is not provided, every sequences are compared against every other sequences resulting in N(seqs)**2 combinations.
@@ -421,6 +429,8 @@ def symdel(seqs, max_edits=1, max_returns=None, n_cpu=1,
         format of returns, can be "triplets", "coo_matrix", or "ndarray"
     seq2 : iterable of strings or None
         another list of CDR3B sequences to compare against
+    progress : bool
+        show progress bar
 
     Returns
     -------
@@ -445,7 +455,7 @@ def symdel(seqs, max_edits=1, max_returns=None, n_cpu=1,
     seqs2_patch = seqs if single_seqs_mode else seqs2
     index = _generate_index(seqs, max_edits)
     triplets = _symdel_lookup(index, seqs, max_edits, max_returns,
-                               custom_distance, max_custom_distance, seqs2_patch, single_seqs_mode)
+                               custom_distance, max_custom_distance, seqs2_patch, single_seqs_mode, progress)
     return _make_output(triplets, output_type, seqs, seqs2)
 
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ REQUIRES = [
     "logomaker",
     "biopython",
     "tidytcells~=2.0",
-    "tqdm==4.66.4",
+    "tqdm",
 ]
 
 DEV_DEPENDENCIES = [

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ REQUIRES = [
     "logomaker",
     "biopython",
     "tidytcells~=2.0",
+    "tqdm==4.66.4",
 ]
 
 DEV_DEPENDENCIES = [

--- a/tests/test_nearest_neighbor.py
+++ b/tests/test_nearest_neighbor.py
@@ -160,3 +160,10 @@ def test_bulk(algorithm):
 
     fuzzy_version = algorithm(test_input, max_edits=2, n_cpu=4)
     assert set_equal(fallback_cache, fuzzy_version)
+
+def test_symdel_progress():
+    test_input1 = ["CAAA", "CADA", "CAAA", "CDKD", "CAAK"]
+    test_input2 = ["CDDD", "CAAK"]
+    test_output = [(1,0,1), (1,2,1), (0,3,1),(1,4,0)]
+    assert set_equal(symdel(test_input1, max_edits=1,
+                               seqs2=test_input2, progress=True), test_output)


### PR DESCRIPTION
_Issue_: For large lists, `nn.symdel` can take an extended amount of time. It would be helpful to see the progress of the algorithm.

_Solution_: Add an optional `tqdm` progress bar to the main loop of `_symdel_lookup`.

Changes:
- Add `tqdm` dependency
- Add new `progress` argument to both `symdel` and `symdel_lookup`
- Add logic to wrap `enumerate(seq2)` if `progress=True`, by default it is false and behaviour is unchanged
- Uses `tqdm.auto.tqdm` to support both CLI and notebooks 
- Add unit test for `progress` functionality

Let me know if you'd like any changes!