### PR TITLE
Symdel manual lookup

### DIFF
--- a/pyrepseq/nn.py
+++ b/pyrepseq/nn.py
@@ -117,7 +117,7 @@ def kdtree(
 
     Parameters
     ----------
-    strings : iterable of strings
+    seqs : iterable of strings
         list of CDR3B sequences
     max_edits : int
         maximum edit distance defining the neighbors
@@ -279,7 +279,7 @@ def hash_based(
 
     Parameters
     ----------
-    strings : iterable of strings
+    seqs : iterable of strings
         list of CDR3B sequences
     max_edits : int
         maximum edit distance defining the neighbors
@@ -412,7 +412,7 @@ def symdel(seqs, max_edits=1, max_returns=None, n_cpu=1,
 
     Parameters
     ----------
-    strings : iterable of strings
+    seqs : iterable of strings
         list of CDR3B sequences
     max_edits : int
         maximum edit distance defining the neighbors
@@ -474,7 +474,7 @@ def nearest_neighbor(seqs, max_edits=1, max_returns=None, n_cpu=1,
 
     Parameters
     ----------
-    strings : iterable of strings
+    seqs : iterable of strings
         list of CDR3B sequences
     max_edits : int
         maximum edit distance defining the neighbors

--- a/pyrepseq/nn.py
+++ b/pyrepseq/nn.py
@@ -413,14 +413,17 @@ class SymdelDB:
             seqs2_loop = enumerate(seqs2)
 
         for i, seq in seqs2_loop:
+            j_indices = set()
             for comb in _comb_gen(seq, self.max_edits):
                 if comb not in self.variant_dict:
                     continue
                 for j in self.variant_dict[comb]:
-                    dist = custom_distance(seqs2[i], self.seqs[j])
-                    if dist > threshold:
-                        continue
-                    ans.append((i, j, dist))
+                    j_indices.add(j)
+            for j in j_indices:
+                dist = custom_distance(seqs2[i], self.seqs[j])
+                if dist > threshold:
+                    continue
+                ans.append((i, j, dist))
 
         return _make_output(ans, output_type, self.seqs, seqs2)
 
@@ -503,6 +506,8 @@ def symdel(seqs, max_edits=1, max_returns=None, n_cpu=1,
                     continue
                 ans.append((i, j, dist))
                 ans.append((j, i, dist))
+        # drop duplicates
+        ans = list(set(ans))
         return _make_output(ans, output_type, seqs, seqs2)
 
     return symdeldb.lookup(seqs2, custom_distance=custom_distance,

--- a/tests/test_nearest_neighbor.py
+++ b/tests/test_nearest_neighbor.py
@@ -25,6 +25,9 @@ def fallback(seqs, max_edits=1):
 
 
 def set_equal(list_a, list_b):
+    "Test for equality regardless of order"
+    if len(list_a) != len(list_b):
+        return False
     # normal set equality is slow in python, so we implement one
     set_a, set_b = set(list_a), set(list_b)
     return len(set_a) == len(set_b) == len(set_a & set_b)
@@ -45,7 +48,8 @@ def test_duplicate(algorithm):
     test_input = ['CAAA', 'CDDD', 'CADA', 'CAAA']
     test_output = [(0, 3, 0), (0, 2, 1), (2, 0, 1),
                    (2, 3, 1), (3, 0, 0), (3, 2, 1)]
-    assert set_equal(algorithm(test_input, max_edits=1), test_output)
+    result = algorithm(test_input, max_edits=1)
+    assert set_equal(result, test_output)
 
     fallback_version = fallback(test_input)
     assert set_equal(fallback_version, test_output)
@@ -89,6 +93,11 @@ def test_symdel_lookup():
 
     symdeldb = SymdelDB(test_reference, max_edits=1)
     result = symdeldb.lookup(test_query)
+    assert set_equal(result, test_output)
+
+    test_duplicate = ["CDDD", "CCCC"]
+    test_output = [(0, 1, 0)]
+    result = symdeldb.lookup(test_duplicate)
     assert set_equal(result, test_output)
 
 def test_tcrdist():

--- a/tests/test_nearest_neighbor.py
+++ b/tests/test_nearest_neighbor.py
@@ -83,13 +83,13 @@ def test_custom_distance(algorithm):
 
 
 def test_symdel_lookup():
-    test_input = ["CAAA", "CDDD", "CADA", "CAAK"]
-    test_output = [(0, 2, 1), (0, 3, 1), (2, 0, 1), (3, 0, 1)]
+    test_reference = ["CAAA", "CDDD", "CADA", "CAAK"]
+    test_query = ["CAAF", "CCCC"]
+    test_output = [(0, 0, 1), (0, 3, 1)]
 
-    symdel_dict = generate_symdel_dict(test_input, max_edits=1)
-    result = symdel_lookup(symdel_dict, test_input, max_edits=1)
+    symdel_dict = generate_symdel_dict(test_reference, max_edits=1)
+    result = symdel_lookup(symdel_dict, seqs=test_reference, seqs2=test_query, max_edits=1)
     assert set_equal(result, test_output)
-
 
 def test_tcrdist():
     df = pd.DataFrame(columns=['CDR3B','TRBV'], data=

--- a/tests/test_nearest_neighbor.py
+++ b/tests/test_nearest_neighbor.py
@@ -1,5 +1,5 @@
 import pytest
-from pyrepseq.nn import hash_based, kdtree, symdel, nearest_neighbor_tcrdist, symdel_manual_lookup
+from pyrepseq.nn import hash_based, kdtree, symdel, nearest_neighbor_tcrdist, symdel_lookup, generate_symdel_dict
 from itertools import product
 from Levenshtein import distance
 import numpy as np
@@ -39,11 +39,6 @@ def test_basic(algorithm):
     fallback_version = fallback(test_input)
     assert set_equal(fallback_version, test_output)
 
-    test_output = [(0, 2, 1), (2, 0, 1), (3, 0, 1)]
-
-    assert set_equal(algorithm(test_input, max_edits=1,
-                               max_returns=1), test_output)
-
 
 @pytest.mark.parametrize("algorithm", ALGORITHMS)
 def test_duplicate(algorithm):
@@ -54,9 +49,6 @@ def test_duplicate(algorithm):
 
     fallback_version = fallback(test_input)
     assert set_equal(fallback_version, test_output)
-
-    output = set(algorithm(test_input, max_edits=1, max_returns=1))
-    assert len(output) == 3 == len(set(test_output) & output)
 
 
 @pytest.mark.parametrize("algorithm", ALGORITHMS)
@@ -84,22 +76,18 @@ def test_custom_distance(algorithm):
     assert set_equal(algorithm(test_input, max_edits=1,
                                custom_distance=distance), test_output)
 
-    output = set(algorithm(test_input, max_edits=1, max_returns=1,
-                           custom_distance=distance))
-    assert len(output) == 3 == len(output & set(test_output))
-
     test_output = []
-    assert set_equal(algorithm(test_input, max_edits=1, max_returns=1,
+    assert set_equal(algorithm(test_input, max_edits=1,
                                custom_distance=distance,
                                max_custom_distance=0), test_output)
 
 
-def test_symdel_manual_lookup():
+def test_symdel_lookup():
     test_input = ["CAAA", "CDDD", "CADA", "CAAK"]
     test_output = [(0, 2, 1), (0, 3, 1), (2, 0, 1), (3, 0, 1)]
 
-    index = symdel(test_input, max_edits=1, output_type="hashmap")
-    result = symdel_manual_lookup(index, test_input, max_edits=1)
+    symdel_dict = generate_symdel_dict(test_input, max_edits=1)
+    result = symdel_lookup(symdel_dict, test_input, max_edits=1)
     assert set_equal(result, test_output)
 
 

--- a/tests/test_nearest_neighbor.py
+++ b/tests/test_nearest_neighbor.py
@@ -1,5 +1,5 @@
 import pytest
-from pyrepseq.nn import hash_based, kdtree, symdel, nearest_neighbor_tcrdist, symdel_lookup, generate_symdel_dict
+from pyrepseq.nn import hash_based, kdtree, symdel, nearest_neighbor_tcrdist, SymdelDB
 from itertools import product
 from Levenshtein import distance
 import numpy as np
@@ -87,8 +87,8 @@ def test_symdel_lookup():
     test_query = ["CAAF", "CCCC"]
     test_output = [(0, 0, 1), (0, 3, 1)]
 
-    symdel_dict = generate_symdel_dict(test_reference, max_edits=1)
-    result = symdel_lookup(symdel_dict, seqs=test_reference, seqs2=test_query, max_edits=1)
+    symdeldb = SymdelDB(test_reference, max_edits=1)
+    result = symdeldb.lookup(test_query)
     assert set_equal(result, test_output)
 
 def test_tcrdist():

--- a/tests/test_nearest_neighbor.py
+++ b/tests/test_nearest_neighbor.py
@@ -1,5 +1,5 @@
 import pytest
-from pyrepseq.nn import hash_based, kdtree, symdel, nearest_neighbor_tcrdist
+from pyrepseq.nn import hash_based, kdtree, symdel, nearest_neighbor_tcrdist, symdel_manual_lookup
 from itertools import product
 from Levenshtein import distance
 import numpy as np
@@ -92,6 +92,15 @@ def test_custom_distance(algorithm):
     assert set_equal(algorithm(test_input, max_edits=1, max_returns=1,
                                custom_distance=distance,
                                max_custom_distance=0), test_output)
+
+
+def test_symdel_manual_lookup():
+    test_input = ["CAAA", "CDDD", "CADA", "CAAK"]
+    test_output = [(0, 2, 1), (0, 3, 1), (2, 0, 1), (3, 0, 1)]
+
+    index = symdel(test_input, max_edits=1, output_type="hashmap")
+    result = symdel_manual_lookup(index, test_input, max_edits=1)
+    assert set_equal(result, test_output)
 
 
 def test_tcrdist():


### PR DESCRIPTION
Add new feature to speed up the use case of multiple Symdel queries of the same dataset.

The implementation add new output_type parameter "hashmap" to symdel function which returns indexed data and a new function symdel_manual_lookup to query from this indexed data.
