### PR TITLE
Gracefully handle bad TR V genes

### DIFF
--- a/pyrepseq/nn.py
+++ b/pyrepseq/nn.py
@@ -690,20 +690,22 @@ def _vdists_lookup(df: pd.DataFrame, row_labels, col_labels):
     ridx = df.index.get_indexer(row_labels_imputed)
     cidx = df.columns.get_indexer(col_labels_imputed)
 
-    if (ridx == -1).any():
-        first_offending_idx = (ridx == -1).argmax()
-        raise ValueError(
-            f"{row_labels.iloc[first_offending_idx]} is not recognized as a valid V gene"
-        )
+    offending_ridcs = np.where(ridx == -1)[0]
+    offending_cidcs = np.where(cidx == -1)[0]
+    offending_idcs = np.unique(np.concatenate([offending_ridcs, offending_cidcs]))
 
-    if (cidx == -1).any():
-        first_offending_idx = (cidx == -1).argmax()
-        raise ValueError(
-            f"{col_labels.iloc[first_offending_idx]} is not recognized as a valid V gene"
-        )
+    for i in offending_ridcs:
+        warnings.warn(f"{row_labels.iloc[i]} is not recognized as a valid V gene")
+
+    for i in offending_cidcs:
+        warnings.warn(f"{col_labels.iloc[i]} is not recognized as a valid V gene")
 
     flat_index = ridx * len(df.columns) + cidx
-    return values.flat[flat_index]
+
+    results = values.flat[flat_index]
+    results[offending_idcs] = 999999
+
+    return results
 
 
 def nearest_neighbor_tcrdist(

--- a/pyrepseq/nn.py
+++ b/pyrepseq/nn.py
@@ -680,27 +680,49 @@ def nearest_neighbor(
     )
 
 
-def _vdists_lookup(df: pd.DataFrame, row_labels, col_labels):
+def _vdists_lookup(dist_reference: pd.DataFrame, lhs: pd.Series, rhs: pd.Series):
+    """
+    Parameters
+    ----------
+    dist_reference : DataFrame
+        Distance matrix loaded as a Pandas DataFrame. The index and column
+        names of the matrix are the symdols of valid TR V genes.
+
+    lhs : Series
+        Series of TR gene symbols, with length L. Symbols only specified up to
+        the gene level will have the allele designator "*01" imputed.
+
+    rhs : Series
+        Series of TR gene symbols, with length L. Symbols only specified up to
+        the gene level will have the allele designator "*01" imputed.
+
+    Returns
+    -------
+    dists : NDArray
+        1D array of length L. dists[i] = tcrdist(lhs[i], rhs[i]). If either
+        lhs[i] or rhs[i] are unrecogized V gene names not found in
+        precomputed_dists, then dists[i] == 999999.
+    """
     # Add "*01" to the end of a V gene symbol if no allele specifier present
-    row_labels_imputed = row_labels.str.replace(r"^([-/\w]+?)$", r"\1*01", regex=True)
-    col_labels_imputed = col_labels.str.replace(r"^([-/\w]+?)$", r"\1*01", regex=True)
+    lhs_imputed = lhs.str.replace(r"^([-/\w]+?)$", r"\1*01", regex=True)
+    rhs_imputed = rhs.str.replace(r"^([-/\w]+?)$", r"\1*01", regex=True)
 
-    values = df.values
+    values = dist_reference.values
 
-    ridx = df.index.get_indexer(row_labels_imputed)
-    cidx = df.columns.get_indexer(col_labels_imputed)
+    lidx = dist_reference.index.get_indexer(lhs_imputed)
+    ridx = dist_reference.columns.get_indexer(rhs_imputed)
 
+    offending_lidcs = np.where(lidx == -1)[0]
     offending_ridcs = np.where(ridx == -1)[0]
-    offending_cidcs = np.where(cidx == -1)[0]
-    offending_idcs = np.unique(np.concatenate([offending_ridcs, offending_cidcs]))
+    offending_idcs = np.unique(np.concatenate([offending_lidcs, offending_ridcs]))
+
+    for i in offending_lidcs:
+        warnings.warn(f"{lhs.iloc[i]} is not recognized as a valid V gene")
 
     for i in offending_ridcs:
-        warnings.warn(f"{row_labels.iloc[i]} is not recognized as a valid V gene")
+        warnings.warn(f"{rhs.iloc[i]} is not recognized as a valid V gene")
 
-    for i in offending_cidcs:
-        warnings.warn(f"{col_labels.iloc[i]} is not recognized as a valid V gene")
-
-    flat_index = ridx * len(df.columns) + cidx
+    flat_index = lidx * len(dist_reference.columns) + ridx
 
     results = values.flat[flat_index]
     results[offending_idcs] = 999999

--- a/tests/test_nearest_neighbor.py
+++ b/tests/test_nearest_neighbor.py
@@ -199,6 +199,42 @@ class TestTcrdist:
             results, np.array([[2, 0, self.alpha_cdist + self.beta_cdist]])
         )
 
+    df3 = pd.DataFrame(
+        columns=["TRAV", "CDR3A", "TRBV", "CDR3B"],
+        data=[
+            [
+                "TRAV21*01",
+                "CASLDSNYQLIW",
+                "TRBV11-2*01",
+                "CASSTGGETQYF",
+            ],
+            [
+                "TRAV420",
+                "CASLDSNYQLIW",
+                "TRBV11-2*01",
+                "CASSTGGETQYF",
+            ],
+        ],
+    )
+
+    def test_tcrdist_cross(self):
+        with pytest.warns(match="is not recognized as a valid V gene"):
+            results = nearest_neighbor_tcrdist(
+                self.df3, max_edits=2, max_tcrdist=30, chain="alpha"
+            )
+            assert results.size == 0
+
+        results = nearest_neighbor_tcrdist(
+            self.df3, max_edits=2, max_tcrdist=30, chain="beta"
+        )
+        assert np.array_equal(results, np.array([[1, 0, 0], [0, 1, 0]]))
+
+        with pytest.warns(match="is not recognized as a valid V gene"):
+            results = nearest_neighbor_tcrdist(
+                self.df3, max_edits=2, max_tcrdist=30, chain="both"
+            )
+            assert results.size == 0
+
 
 # symdel is the only algorithm supporting 2-seq mode
 def test_two_sequence():

--- a/tests/test_nearest_neighbor.py
+++ b/tests/test_nearest_neighbor.py
@@ -217,7 +217,7 @@ class TestTcrdist:
         ],
     )
 
-    def test_tcrdist_cross(self):
+    def test_tcrdist_cross_bad_v_genes(self):
         with pytest.warns(match="is not recognized as a valid V gene"):
             results = nearest_neighbor_tcrdist(
                 self.df3, max_edits=2, max_tcrdist=30, chain="alpha"


### PR DESCRIPTION
- Catches unrecognized TR V genes gracefully and imputes with a very high distance as the true distance is unknown
- @andim we discussed about returning a nan earlier so this current implemented behaviour is slightly different -- are you happy with this? Or would you like the `nearest_neighbor_tcrdist` to return nan where the V genes are not recognised